### PR TITLE
Refactor plugin config for lolcommits v0.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ cache: bundler
 rvm:
  - 2.0.0
  - 2.1.10
- - 2.2.8
- - 2.3.5
- - 2.4.2
+ - 2.2.9
+ - 2.3.6
+ - 2.4.3
+ - 2.5.0
  - ruby-head
 
 before_install:
- - gem install bundler -v 1.13.7
+ - gem update --system
  - git --version
  - git config --global user.email "lol@commits.org"
  - git config --global user.name "Lolcommits"

--- a/lib/lolcommits/plugin/protonet.rb
+++ b/lib/lolcommits/plugin/protonet.rb
@@ -10,16 +10,7 @@ module Lolcommits
       #
       def initialize(runner: nil, config: nil)
         super
-        options.concat(plugin_options)
-      end
-
-      ##
-      # Returns the name of the plugin to identify the plugin to lolcommits.
-      #
-      # @return [String] the plugin name
-      #
-      def self.name
-        'protonet'
+        options.concat([:api_endpoint, :api_token])
       end
 
       ##
@@ -50,18 +41,6 @@ module Lolcommits
       end
 
       ##
-      # Returns true if the plugin has been configured.
-      #
-      # @return [Boolean] true/false indicating if plugin is configured. An API
-      # token and endpoint are required.
-      #
-      def configured?
-        !!(configuration['enabled'] &&
-           configuration['api_token'] &&
-           configuration['api_endpoint'])
-      end
-
-      ##
       # Post-capture hook, runs after lolcommits captures a snapshot. Posts the
       # lolcommit image with a message to the Protonet box. API Documentation
       # can be found on the Protonet box under Help/"Protonet REST API"
@@ -70,14 +49,14 @@ module Lolcommits
       # @return [Nil] if any error occurs
       #
       def run_capture_ready
-        debug "Posting image (and message) to #{configuration['api_endpoint']}"
+        debug "Posting image (and message) to #{configuration[:api_endpoint]}"
         RestClient.post(
-          configuration['api_endpoint'],
+          configuration[:api_endpoint],
           {
             files: [File.new(runner.main_image)],
             message: message
           },
-          'X-Protonet-Token' => configuration['api_token']
+          'X-Protonet-Token' => configuration[:api_token]
         )
       rescue => e
         log_error(e, "ERROR: RestClient POST FAILED #{e.class} - #{e.message}")
@@ -124,16 +103,6 @@ module Lolcommits
           ' - Tavonius would be proud of this - ', 'Meg FAILMAN!', '- very brofessional of you -',
           'heartbleeding', 'juciy', 'supercalifragilisticexpialidocious', 'failing', 'loving'
         ].sample
-      end
-
-      ##
-      # Returns all configuration options available for this plugin. An API
-      # endpoint and token.
-      #
-      # @return [Array] the option names
-      #
-      def plugin_options
-        %w(api_endpoint api_token)
       end
     end
   end

--- a/lib/lolcommits/protonet/version.rb
+++ b/lib/lolcommits/protonet/version.rb
@@ -1,5 +1,5 @@
 module Lolcommits
   module Protonet
-    VERSION = "0.0.2".freeze
+    VERSION = "0.0.3".freeze
   end
 end

--- a/lolcommits-protonet.gemspec
+++ b/lolcommits-protonet.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "rest-client"
 
-  spec.add_development_dependency "lolcommits", ">= 0.9.5"
+  spec.add_development_dependency "lolcommits", ">= 0.10.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
* require at least lolcommits >= 0.10.0
* drop`self.name` method (plugins are now identified by their gem name)
* drop calls to `configured?` (no longer available or useful)
* symbolize all plugin config keys
* update rubies for Travis CI
* bump gem version (for new plugin release)