### PR TITLE
chore: drop ruby 2.3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.3.8
   - 2.4.6
   - 2.5.5
   - 2.6.3


### PR DESCRIPTION
drop ruby 2.3.8 support, as main gem `lolcommits` dosn't support it anymore. 

---
#### :memo: Checklist

Please check this list and leave it intact for the reviewer. Thanks! :heart:

- [x] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [ ] If relevant, mention GitHub issue number above and include in a commit message.
- [x] Latest code from master merged.
- [ ] New behaviour has test coverage.
- [x] Avoid duplicating code.
- [x] No commented out code.
- [x] Avoid comments for your code, write code that explains itself.
- [x] Changes are simple, useful, clear and brief.
